### PR TITLE
Increases max products in dropdown (50 -> 250)

### DIFF
--- a/shopify/fieldtypes/Shopify_ProductFieldType.php
+++ b/shopify/fieldtypes/Shopify_ProductFieldType.php
@@ -16,13 +16,15 @@ class Shopify_ProductFieldType extends BaseFieldType
 	 */
 	public function getInputHtml($name, $value)
 	{
-		$products = craft()->shopify->getProducts();
+		$productOptions = array('limit' => 250);
+		$products = craft()->shopify->getProducts($productOptions);
 
+		$options = array();
 		foreach ($products as $product) {
 			$options[] = array(
-							'label' => $product['title'],
-							'value' => $product['id']
-						);
+				'label' => $product['title'],
+				'value' => $product['id']
+			);
 		}
 
 		return craft()->templates->render('shopify/_select', array(


### PR DESCRIPTION
This resolves an issue where the field's dropdown menu was only displaying the first 50 products (the default limit). Instead, we're now specifying a maximum of 250 products (the max per this API call).

Ultimately, this number could _potentially_ be set via some a field setting. But that's a bit beyond the simple fix that I was aiming for.

Fixes #2 