### PR TITLE
Properly format dropdown menu

### DIFF
--- a/shopify/templates/_select.html
+++ b/shopify/templates/_select.html
@@ -1,6 +1,8 @@
-<select name="{{ name }}" id="{{ name }}">
-	<option value=""></option>
-	{% for option in options %}
-		<option value="{{ option.value }}"{% if value == option.value %} selected{% endif %}>{{ option.label }}</option>
-	{% endfor %}
-</select>
+<div class="select">
+	<select name="{{ name }}" id="{{ name }}">
+		<option value=""></option>
+		{% for option in options %}
+			<option value="{{ option.value }}"{% if value == option.value %} selected{% endif %}>{{ option.label }}</option>
+		{% endfor %}
+	</select>
+</div>


### PR DESCRIPTION
This is really a minor formatting fix. By wrapping the `select` menu with this...

    <div class="select">

... it now properly formats the dropdown to match Craft's native fields.