### PR TITLE
Created new ProductModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Craft plugin to integrate with the Shopify API
 
 ### craft.shopify.getProducts
 
-Retrieve all products from Shopify. You can pass in any parameters that are noted in the [products enpoint](http://docs.shopify.com/api/product#index). Example:
+Retrieve all products from Shopify. You can pass in any parameters that are noted in the [products endpoint](http://docs.shopify.com/api/product#index). Example:
 
 ```
 {% for product in craft.shopify.getProducts({ fields: 'title,variants', limit: 5 }) %}
@@ -38,9 +38,9 @@ This is just a slightly modified version of the getProducts method where the arr
 	<div class="product">
 		<h2><a href="{{ entry.url }}">{{ entry.title }}</a></h2>
 
-		{% if entry.shopifyProduct and shopifyProducts[entry.shopifyProduct] %}
+		{% if entry.shopifyProduct and shopifyProducts[entry.shopifyProduct.productId] %}
 			<ul>
-				{% for variant in shopifyProducts[entry.shopifyProduct] %}
+				{% for variant in shopifyProducts[entry.shopifyProduct.productId] %}
 					<li>{{ variant.title }} - ${{ variant.price }}</li>
 				{% endfor %}
 			</ul>
@@ -66,3 +66,22 @@ Useful on product show pages to access Shopify product information. Useful to ge
 	<button type="submit">Add to Cart</button>
 </form>
 ```
+
+---
+
+### Minor breaking change (v1.0.3)
+
+Your `entry.shopifyProduct` value is now a _model_ (whereas it was previously a simple integer).
+
+If your `entry.shopifyProduct` is being directly output as an ID string, no change is necessary.
+
+    {# No change #}
+    {{ entry.shopifyProduct }}
+
+If your `entry.shopifyProduct` is being used in a _comparison operation_, then you'll need to append `.productId` to it.
+
+    {# Previous comparison #}
+    {% if entry.shopifyProduct == 101 %}
+    
+    {# New comparison #}
+    {% if entry.shopifyProduct.productId == 101 %}

--- a/shopify/ShopifyPlugin.php
+++ b/shopify/ShopifyPlugin.php
@@ -15,7 +15,7 @@ class ShopifyPlugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '1.0.2';
+		return '1.0.3';
 	}
 
 	public function getSchemaVersion()

--- a/shopify/fieldtypes/Shopify_ProductFieldType.php
+++ b/shopify/fieldtypes/Shopify_ProductFieldType.php
@@ -33,4 +33,15 @@ class Shopify_ProductFieldType extends BaseFieldType
 			'options' => $options
 		));
 	}
+
+	/**
+	 * As the data leaves the database
+	 *
+	 * @param string $value ID of Shopify product
+	 * @return Shopify_ProductModel
+	 */
+	public function prepValue($value)
+	{
+		return craft()->shopify->getProductModel($this, $value);
+	}
 }

--- a/shopify/models/Shopify_ProductModel.php
+++ b/shopify/models/Shopify_ProductModel.php
@@ -1,0 +1,34 @@
+<?php
+namespace Craft;
+
+class Shopify_ProductModel extends BaseModel
+{
+
+	public function __toString()
+	{
+		return (string) $this->productId;
+	}
+
+	protected function defineAttributes()
+	{
+		return array(
+			'productId' => AttributeType::Number,
+		);
+	}
+
+	/**
+	 * Get the product details
+	 *
+	 * @return string
+	 */
+	public function details($fields = '')
+	{
+		$options = array(
+			'id' => $this->productId,
+			'fields' => $fields
+		);
+		$product = craft()->shopify->getProductById($options);
+		return $product;
+	}
+
+}

--- a/shopify/services/ShopifyService.php
+++ b/shopify/services/ShopifyService.php
@@ -57,8 +57,8 @@ class ShopifyService extends BaseApplicationComponent
 	 */
 	public function getProductById($options = array())
 	{
-		$id = $options['id'];
-		$fields = isset($options['fields']) ? '?fields=' . $options['fields'] : '';
+		$id = (string) $options['id'];
+		$fields = isset($options['fields']) && $options['fields'] ? '?fields=' . $options['fields'] : '';
 		$url = $this->_getShopifyUrl('admin/products/' . $id . '.json' . $fields);
 
 		try {
@@ -88,4 +88,19 @@ class ShopifyService extends BaseApplicationComponent
 	{
 		return 'https://' . $this->apiKey . ':' . $this->password . '@' . $this->hostname . '/' . $endpoint;
 	}
+
+	/**
+	 * Retrieves product model
+	 *
+	 * @param Shopify_ProductFieldType $field
+	 * @param mixed $value
+	 * @return Shopify_ProductModel
+	 */
+	public function getProductModel(Shopify_ProductFieldType $field, $value)
+	{
+		$model = new Shopify_ProductModel;
+		$model->productId = $value;
+		return $model;
+	}
+
 }

--- a/shopify/templates/_select.html
+++ b/shopify/templates/_select.html
@@ -2,7 +2,8 @@
 	<select name="{{ name }}" id="{{ name }}">
 		<option value=""></option>
 		{% for option in options %}
-			<option value="{{ option.value }}"{% if value == option.value %} selected{% endif %}>{{ option.label }}</option>
+			{% set selected = (value and (value.productId == option.value) ? 'selected' : '') %}
+			<option value="{{ option.value }}" {{ selected }}>{{ option.label }}</option>
 		{% endfor %}
 	</select>
 </div>


### PR DESCRIPTION
This one is a little heavier... hence why I'm submitting it separately.

---

Essentially, this PR converts the field value into a `ProductModel`, which can contain the **full details** of a given product. This saves us the trouble of explicitly making an API call to get the product details.

    {% set product = entry.shopifyProduct.details %}

In the above example, `shopifyProduct` is our Shopify field (based on the existing Product fieldtype). However, instead of the field returning a simple product ID integer, it now returns a full `ProductModel`.

    {# ProductModel #}
    entry.shopifyProduct

Since this is a model, and not just a simple integer, we can quickly expand on its capabilities. The simple expansion that I implemented was to create a `details` method on the model. So by tacking on `.details`, you immediately get the full Shopify details for the current product.

    {# Full product details #}
    entry.shopifyProduct.details

If you only want certain fields, just pass those into `details`...

    {# Select product details #}
    entry.shopifyProduct.details('images,variants')

Of course, it was already possible to get this information... but the existing approach is very verbose by comparison.

    {# Existing #}
    {% set shopify = craft.shopify.getProductById({ id: entry.shopifyProduct, fields: 'images,variants' }) %}
    
    {# New #}
    {% set shopify = entry.shopifyProduct.details('images,variants') %}

For the record, this _does not replace_ the original technique. Both now exist, so users can use whichever method is more comfortable for them.

Lastly, if you output a `ProductModel` directly, its `__toString` method will return the Product ID. This should keep behavior consistent for any existing implementations.

It's important to note, however, that a minor patch may be needed for anyone doing a comparison on the field value... Twig will automatically convert `__toString` when it's obvious, but not when the value is used in comparisons.

Fortunately, the fix for those cases is very easy... you simply need to append `productId` to the model.

    {# Previous comparison #}
    {% if entry.shopifyProduct == 101 %}
    
    {# New comparison #}
    {% if entry.shopifyProduct.productId == 101 %}

I've already noted this minor breaking change in the README, and bumped the version number to `1.0.3` as a point of reference.

---

Whew, that was long-winded... Let me know if you have any questions!

Thanks Trevor!