### PR TITLE
Get all products from stores with more than 250 products

### DIFF
--- a/shopify/ShopifyPlugin.php
+++ b/shopify/ShopifyPlugin.php
@@ -15,7 +15,7 @@ class ShopifyPlugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '1.0.2';
+		return '1.0.3';
 	}
 
 	public function getSchemaVersion()

--- a/shopify/fieldtypes/Shopify_ProductFieldType.php
+++ b/shopify/fieldtypes/Shopify_ProductFieldType.php
@@ -16,8 +16,22 @@ class Shopify_ProductFieldType extends BaseFieldType
 	 */
 	public function getInputHtml($name, $value)
 	{
-		$productOptions = array('limit' => 250);
-		$products = craft()->shopify->getProducts($productOptions);
+	    $limit = 250;
+	    $page = 1;
+	    $fields = 'id,title';
+
+		$productOptions = array('limit' => $limit, 'page' => $page, 'fields' => $fields);
+		$getProducts = craft()->shopify->getProducts($productOptions);
+		$products = $getProducts;
+
+        if (count($getProducts) == $limit) {
+            while (count($getProducts) > 0) {
+                $page++;
+                $productOptions = array('limit' => $limit, 'page' => $page, 'fields' => $fields);
+                $getProducts = craft()->shopify->getProducts($productOptions);
+                $products = array_merge($products, $getProducts);
+            }
+        }
 
 		$options = array();
 		foreach ($products as $product) {


### PR DESCRIPTION
I've made some changes:

- Fetch all products from a store with more than 250 products. It checks the next page of results until the results are empty and adds it to the `$products` array.
- Only fetch the fields that are needed for the **Shopify Product** field type. This really speeds things up. 🚀
